### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: pre-commit check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nijel/proteus-api-ha/security/code-scanning/1](https://github.com/nijel/proteus-api-ha/security/code-scanning/1)

To fix the problem, add an explicit `permissions` section to the workflow to restrict the `GITHUB_TOKEN` to the least privileges required. Since this `pre-commit` job only checks code and does not push changes, comment on PRs, or otherwise modify repository state, it should only need read access to repository contents. The simplest and safest change is to add `permissions: contents: read` at the workflow root so it applies to all jobs in this workflow.

Concretely, in `.github/workflows/pre-commit.yml`, insert a `permissions` block after the `name:` line (before `on:`). This will set default permissions for the entire workflow. No imports or additional methods are required because this is a YAML configuration change only. The final structure at the top of the file should be:

```yaml
name: pre-commit check
permissions:
  contents: read

on:
  push:
  pull_request:
...
```

No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
