### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -6,6 +6,9 @@ on:
   schedule:
   - cron: 0 0 * * *
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nijel/proteus-api-ha/security/code-scanning/2](https://github.com/nijel/proteus-api-ha/security/code-scanning/2)

To fix the problem, explicitly declare restricted `GITHUB_TOKEN` permissions in the workflow, instead of inheriting repository defaults. The least-privilege approach for this validation workflow is to grant read-only access to repository contents, which is sufficient for `actions/checkout` to function and for `home-assistant/actions/hassfest` to read the codebase.

The best fix, without changing existing functionality, is to add a `permissions` block at the workflow root (top level, alongside `name`, `on`, and `jobs`). This will apply to all jobs in the workflow, including `validate`, unless a job overrides it. In `.github/workflows/hassfest.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (e.g., after line 7 and the blank line at line 8). No additional imports or definitions are required because this is purely a YAML configuration change within the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
