### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,4 +1,6 @@
 name: HACS Action
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nijel/proteus-api-ha/security/code-scanning/3](https://github.com/nijel/proteus-api-ha/security/code-scanning/3)

To fix the problem, explicitly define a minimal `permissions` block so that the `GITHUB_TOKEN` has only the rights needed by this workflow. Since the job only checks out code and runs `hacs/action@main` to validate a Home Assistant Custom Component, read access to repository contents is sufficient in most cases.

The safest and simplest fix without changing functionality is:

- Add a root‑level `permissions:` block (applies to all jobs) directly under the workflow `name:` line.
- Set `contents: read` as a minimal starting point, which allows the workflow to read repository contents but not push, delete, or modify them.

Concretely, in `.github/workflows/hacs.yml`, between line 1 (`name: HACS Action`) and line 3 (`on:`), insert:

```yaml
permissions:
  contents: read
```

No imports or other definitions are needed; this is purely a YAML configuration change within the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
