### PR TITLE
fix: allow Home Assistant aiohttp pin

### DIFF
--- a/custom_components/proteus_api/manifest.json
+++ b/custom_components/proteus_api/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/nijel/proteus-api-ha/issues",
   "requirements": [
-    "aiohttp>=3.14.0",
+    "aiohttp>=3.8.0",
     "aiohttp-retry>=2.9.1"
   ],
   "version": "0.4.0"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,26 @@
+"""Tests for Home Assistant manifest metadata."""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+import json
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+MANIFEST_PATH = (
+    Path(__file__).parents[1] / "custom_components" / "proteus_api" / "manifest.json"
+)
+
+
+def test_manifest_accepts_installed_aiohttp_version() -> None:
+    """Manifest requirements should not reject Home Assistant's aiohttp pin."""
+    requirements = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))["requirements"]
+    aiohttp_requirement = next(
+        Requirement(requirement)
+        for requirement in requirements
+        if Requirement(requirement).name == "aiohttp"
+    )
+
+    assert Version(version("aiohttp")) in aiohttp_requirement.specifier


### PR DESCRIPTION
Relax the manifest aiohttp requirement to match project metadata and Home Assistant's bundled version.

Add a manifest regression test that verifies the installed aiohttp version satisfies the integration requirement.